### PR TITLE
Refactored SignInController moving the logic to Oauth2, including get…

### DIFF
--- a/src/main/java/uk/gov/ch/developer/docs/controller/developer/SignInController.java
+++ b/src/main/java/uk/gov/ch/developer/docs/controller/developer/SignInController.java
@@ -1,15 +1,16 @@
 package uk.gov.ch.developer.docs.controller.developer;
 
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import uk.gov.ch.oauth.IOauth;
 import uk.gov.ch.oauth.identity.IIdentityProvider;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
+import uk.gov.companieshouse.session.Session;
+import uk.gov.companieshouse.session.handler.SessionHandler;
 
 @Controller
 @RequestMapping("${signin.url}")
@@ -26,7 +27,8 @@ public class SignInController {
     @GetMapping
     public void doSignIn(final HttpServletRequest httpServletRequest,
                          final HttpServletResponse httpServletResponse) throws IOException {
-        final String state = oauth2.prepareState(httpServletRequest);
+        final Session chSession = (Session) httpServletRequest.getAttribute(SessionHandler.CHS_SESSION_REQUEST_ATT_KEY);
+        final String state = oauth2.prepareState(httpServletRequest, chSession);
         final String authoriseUri = identityProvider.getAuthorisationUrl(state);
         httpServletResponse.sendRedirect(authoriseUri);
     }

--- a/src/main/java/uk/gov/ch/developer/docs/controller/developer/SignInController.java
+++ b/src/main/java/uk/gov/ch/developer/docs/controller/developer/SignInController.java
@@ -16,7 +16,7 @@ public class SignInController {
 
 
     @Autowired
-    private IOauth oauth2;
+    private IOauth oauth;
 
     @Autowired
     IIdentityProvider identityProvider;
@@ -25,7 +25,7 @@ public class SignInController {
     @GetMapping
     public void doSignIn(final HttpServletRequest httpServletRequest,
                          final HttpServletResponse httpServletResponse) throws IOException {
-        final String state = oauth2.prepareState(httpServletRequest);
+        final String state = oauth.prepareState(httpServletRequest);
         final String authoriseUri = identityProvider.getAuthorisationUrl(state);
         httpServletResponse.sendRedirect(authoriseUri);
     }

--- a/src/main/java/uk/gov/ch/developer/docs/controller/developer/SignInController.java
+++ b/src/main/java/uk/gov/ch/developer/docs/controller/developer/SignInController.java
@@ -9,8 +9,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import uk.gov.ch.oauth.IOauth;
 import uk.gov.ch.oauth.identity.IIdentityProvider;
-import uk.gov.companieshouse.session.Session;
-import uk.gov.companieshouse.session.handler.SessionHandler;
 
 @Controller
 @RequestMapping("${signin.url}")
@@ -27,8 +25,7 @@ public class SignInController {
     @GetMapping
     public void doSignIn(final HttpServletRequest httpServletRequest,
                          final HttpServletResponse httpServletResponse) throws IOException {
-        final Session chSession = (Session) httpServletRequest.getAttribute(SessionHandler.CHS_SESSION_REQUEST_ATT_KEY);
-        final String state = oauth2.prepareState(httpServletRequest, chSession);
+        final String state = oauth2.prepareState(httpServletRequest);
         final String authoriseUri = identityProvider.getAuthorisationUrl(state);
         httpServletResponse.sendRedirect(authoriseUri);
     }

--- a/src/main/java/uk/gov/ch/developer/docs/controller/developer/SignInController.java
+++ b/src/main/java/uk/gov/ch/developer/docs/controller/developer/SignInController.java
@@ -1,63 +1,33 @@
 package uk.gov.ch.developer.docs.controller.developer;
 
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import uk.gov.ch.oauth.IOauth;
 import uk.gov.ch.oauth.identity.IIdentityProvider;
-import uk.gov.companieshouse.session.Session;
-import uk.gov.companieshouse.session.handler.SessionHandler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
 @Controller
 @RequestMapping("${signin.url}")
 public class SignInController {
 
+
     @Autowired
-    IOauth oauth;
+    private IOauth oauth2;
 
     @Autowired
     IIdentityProvider identityProvider;
 
-    private static String getRequestURL(final HttpServletRequest request) {
-        // Find the original requested url
-        final StringBuilder originalRequestUrl = new StringBuilder(
-                request.getRequestURL());
-        final String queryString = request.getQueryString();
-        if (queryString != null) {
-            originalRequestUrl.append("?").append(queryString);
-        }
-        return originalRequestUrl.toString();
-    }
 
     @GetMapping
-    public void getSignIn(final HttpServletRequest httpServletRequest,
-            final HttpServletResponse httpServletResponse) throws IOException {
-
-        final Session chSession = (Session) httpServletRequest
-                .getAttribute(SessionHandler.CHS_SESSION_REQUEST_ATT_KEY);
-        // Redirect for user authentication (no scope specified)
-        redirectForAuth(chSession, httpServletRequest, httpServletResponse);
-    }
-
-    /**
-     * Redirects to a URI for the user to authenticate themselves
-     *
-     * @param session The user's session, retrieved from context
-     */
-    void redirectForAuth(final Session session, final HttpServletRequest request,
-            final HttpServletResponse response)
-            throws IOException {
-
-        final String originalRequestUrl = getRequestURL(request);
-
-        // Build oauth uri and redirect
-        final String state = oauth.encodeSignInState(originalRequestUrl, session, "content");
+    public void doSignIn(final HttpServletRequest httpServletRequest,
+                         final HttpServletResponse httpServletResponse) throws IOException {
+        final String state = oauth2.prepareState(httpServletRequest);
         final String authoriseUri = identityProvider.getAuthorisationUrl(state);
-        response.sendRedirect(authoriseUri);
+        httpServletResponse.sendRedirect(authoriseUri);
     }
-
 }

--- a/src/main/java/uk/gov/ch/oauth/IOauth.java
+++ b/src/main/java/uk/gov/ch/oauth/IOauth.java
@@ -43,15 +43,6 @@ public interface IOauth {
     void invalidateSession(Session chSession);
 
     /**
-     * Will get the request URL and transform it into the original URL.
-     *
-     * @param request the request that will be used to get the request URL.
-     * @return The original requested URL as a String
-     */
-    String getOriginalRequestURL(final HttpServletRequest request);
-
-
-    /**
      * This method takes a HttpRequest and returns the state by getting the original request url from
      * getOriginalRequestUrl() and then calling encodeSignInState() to get the state.
      *

--- a/src/main/java/uk/gov/ch/oauth/IOauth.java
+++ b/src/main/java/uk/gov/ch/oauth/IOauth.java
@@ -48,5 +48,5 @@ public interface IOauth {
      * @param request HttpRequest
      * @return The state as a String
      */
-    String prepareState(final HttpServletRequest request, final Session chSession);
+    String prepareState(final HttpServletRequest request);
 }

--- a/src/main/java/uk/gov/ch/oauth/IOauth.java
+++ b/src/main/java/uk/gov/ch/oauth/IOauth.java
@@ -1,9 +1,8 @@
 package uk.gov.ch.oauth;
 
-import uk.gov.companieshouse.session.Session;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import uk.gov.companieshouse.session.Session;
 
 /**
  * Handler for the OAuth sight in flow based on the requirements of the CH version of OAuth2
@@ -49,5 +48,5 @@ public interface IOauth {
      * @param request HttpRequest
      * @return The state as a String
      */
-    String prepareState(final HttpServletRequest request);
+    String prepareState(final HttpServletRequest request, final Session chSession);
 }

--- a/src/main/java/uk/gov/ch/oauth/IOauth.java
+++ b/src/main/java/uk/gov/ch/oauth/IOauth.java
@@ -1,7 +1,9 @@
 package uk.gov.ch.oauth;
 
-import javax.servlet.http.HttpServletResponse;
 import uk.gov.companieshouse.session.Session;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * Handler for the OAuth sight in flow based on the requirements of the CH version of OAuth2
@@ -39,4 +41,22 @@ public interface IOauth {
      * @param chSession The active session.
      */
     void invalidateSession(Session chSession);
+
+    /**
+     * Will get the request URL and transform it into the original URL.
+     *
+     * @param request the request that will be used to get the request URL.
+     * @return The original requested URL as a String
+     */
+    String getOriginalRequestURL(final HttpServletRequest request);
+
+
+    /**
+     * This method takes a HttpRequest and returns the state by getting the original request url from
+     * getOriginalRequestUrl() and then calling encodeSignInState() to get the state.
+     *
+     * @param request HttpRequest
+     * @return The state as a String
+     */
+    String prepareState(final HttpServletRequest request);
 }

--- a/src/main/java/uk/gov/ch/oauth/Oauth2.java
+++ b/src/main/java/uk/gov/ch/oauth/Oauth2.java
@@ -1,6 +1,13 @@
 package uk.gov.ch.oauth;
 
+import static uk.gov.companieshouse.session.handler.SessionHandler.buildSessionCookie;
+
 import com.nimbusds.jose.Payload;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import net.minidev.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -20,15 +27,6 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.session.Session;
 import uk.gov.companieshouse.session.SessionKeys;
-import uk.gov.companieshouse.session.handler.SessionHandler;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.net.URI;
-import java.time.Duration;
-import java.util.Map;
-
-import static uk.gov.companieshouse.session.handler.SessionHandler.buildSessionCookie;
 
 @Component
 public class Oauth2 implements IOauth {
@@ -257,8 +255,7 @@ public class Oauth2 implements IOauth {
 
     }
 
-    public String prepareState(final HttpServletRequest request) {
-        final Session chSession = (Session) request.getAttribute(SessionHandler.CHS_SESSION_REQUEST_ATT_KEY);
+    public String prepareState(final HttpServletRequest request, final Session chSession) {
         String originalURL = getOriginalRequestURL(request);
         return encodeSignInState(originalURL, chSession, "content");
     }

--- a/src/main/java/uk/gov/ch/oauth/Oauth2.java
+++ b/src/main/java/uk/gov/ch/oauth/Oauth2.java
@@ -27,7 +27,6 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.session.Session;
 import uk.gov.companieshouse.session.SessionKeys;
-import uk.gov.companieshouse.session.handler.SessionHandler;
 
 @Component
 public class Oauth2 implements IOauth {
@@ -257,9 +256,8 @@ public class Oauth2 implements IOauth {
     }
 
     public String prepareState(final HttpServletRequest request) {
-        final Session chSession = (Session) request.getAttribute(SessionHandler.CHS_SESSION_REQUEST_ATT_KEY);
         String originalURL = getOriginalRequestURL(request);
-        return encodeSignInState(originalURL, chSession, "content");
+        return encodeSignInState(originalURL, sessionFactory.getSessionFromContext(), "content");
     }
 
 }

--- a/src/main/java/uk/gov/ch/oauth/Oauth2.java
+++ b/src/main/java/uk/gov/ch/oauth/Oauth2.java
@@ -246,7 +246,7 @@ public class Oauth2 implements IOauth {
         }
     }
 
-    public String getOriginalRequestURL(final HttpServletRequest request) {
+    private String getOriginalRequestURL(final HttpServletRequest request) {
         final StringBuilder originalRequestUrl = new StringBuilder(
                 request.getRequestURL());
         final String queryString = request.getQueryString();

--- a/src/main/java/uk/gov/ch/oauth/Oauth2.java
+++ b/src/main/java/uk/gov/ch/oauth/Oauth2.java
@@ -1,10 +1,7 @@
 package uk.gov.ch.oauth;
 
-import static uk.gov.companieshouse.session.handler.SessionHandler.buildSessionCookie;
-import java.net.URI;
-import java.time.Duration;
-import java.util.Map;
-import javax.servlet.http.HttpServletResponse;
+import com.nimbusds.jose.Payload;
+import net.minidev.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ReactiveHttpOutputMessage;
@@ -13,8 +10,6 @@ import org.springframework.web.reactive.function.BodyInserter;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
-import com.nimbusds.jose.Payload;
-import net.minidev.json.JSONObject;
 import reactor.core.publisher.Mono;
 import uk.gov.ch.oauth.identity.IIdentityProvider;
 import uk.gov.ch.oauth.nonce.NonceGenerator;
@@ -25,6 +20,15 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.session.Session;
 import uk.gov.companieshouse.session.SessionKeys;
+import uk.gov.companieshouse.session.handler.SessionHandler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Map;
+
+import static uk.gov.companieshouse.session.handler.SessionHandler.buildSessionCookie;
 
 @Component
 public class Oauth2 implements IOauth {
@@ -241,4 +245,22 @@ public class Oauth2 implements IOauth {
             sessionFactory.getDefaultStore().delete(zxsKey);
         }
     }
+
+    public String getOriginalRequestURL(final HttpServletRequest request) {
+        final StringBuilder originalRequestUrl = new StringBuilder(
+                request.getRequestURL());
+        final String queryString = request.getQueryString();
+        if (queryString != null) {
+            originalRequestUrl.append("?").append(queryString);
+        }
+        return originalRequestUrl.toString();
+
+    }
+
+    public String prepareState(final HttpServletRequest request) {
+        final Session chSession = (Session) request.getAttribute(SessionHandler.CHS_SESSION_REQUEST_ATT_KEY);
+        String originalURL = getOriginalRequestURL(request);
+        return encodeSignInState(originalURL, chSession, "content");
+    }
+
 }

--- a/src/main/java/uk/gov/ch/oauth/Oauth2.java
+++ b/src/main/java/uk/gov/ch/oauth/Oauth2.java
@@ -27,6 +27,7 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.session.Session;
 import uk.gov.companieshouse.session.SessionKeys;
+import uk.gov.companieshouse.session.handler.SessionHandler;
 
 @Component
 public class Oauth2 implements IOauth {
@@ -255,7 +256,8 @@ public class Oauth2 implements IOauth {
 
     }
 
-    public String prepareState(final HttpServletRequest request, final Session chSession) {
+    public String prepareState(final HttpServletRequest request) {
+        final Session chSession = (Session) request.getAttribute(SessionHandler.CHS_SESSION_REQUEST_ATT_KEY);
         String originalURL = getOriginalRequestURL(request);
         return encodeSignInState(originalURL, chSession, "content");
     }

--- a/src/test/java/uk/gov/ch/developer/docs/controller/developer/SignInControllerTest.java
+++ b/src/test/java/uk/gov/ch/developer/docs/controller/developer/SignInControllerTest.java
@@ -15,7 +15,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.ch.oauth.IOauth;
 import uk.gov.ch.oauth.identity.IIdentityProvider;
 import uk.gov.companieshouse.session.Session;
-import uk.gov.companieshouse.session.handler.SessionHandler;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -46,8 +45,7 @@ public class SignInControllerTest {
 
     @Test
     void doSignInTestToEnsureThatAUserIsSentToTheAuthorisePage() throws IOException {
-        when(request.getAttribute(SessionHandler.CHS_SESSION_REQUEST_ATT_KEY)).thenReturn(session);
-        when(oauth2.prepareState(request, session)).thenReturn(STATE);
+        when(oauth2.prepareState(request)).thenReturn(STATE);
         when(identityProvider.getAuthorisationUrl(STATE)).thenReturn(AUTHORISE_URI);
         signInController.doSignIn(request, response);
         verify(response).sendRedirect(AUTHORISE_URI);

--- a/src/test/java/uk/gov/ch/developer/docs/controller/developer/SignInControllerTest.java
+++ b/src/test/java/uk/gov/ch/developer/docs/controller/developer/SignInControllerTest.java
@@ -1,13 +1,5 @@
 package uk.gov.ch.developer.docs.controller.developer;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -17,7 +9,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.ch.oauth.IOauth;
 import uk.gov.ch.oauth.identity.IIdentityProvider;
 import uk.gov.companieshouse.session.Session;
-import uk.gov.companieshouse.session.handler.SessionHandler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -37,7 +35,7 @@ public class SignInControllerTest {
     @Mock
     HttpServletResponse response;
     @Mock
-    IOauth oauth;
+    IOauth oauth2;
     @Mock
     IIdentityProvider identityProvider;
     @Mock
@@ -47,27 +45,10 @@ public class SignInControllerTest {
     private SignInController signInController;
 
     @Test
-    void getSignInTest() throws IOException {
-        when(request.getAttribute(SessionHandler.CHS_SESSION_REQUEST_ATT_KEY)).thenReturn(session);
-        doNothing().when(signInController).redirectForAuth(
-                any(Session.class),
-                any(HttpServletRequest.class),
-                any(HttpServletResponse.class));
-
-        signInController.getSignIn(request, response);
-
-        verify(signInController).redirectForAuth(session, request, response);
-    }
-
-    @Test
-    void redirectForAuthTest() throws IOException {
-        when(request.getRequestURL()).thenReturn(REQUEST_URL_STRING_BUFFER);
-        when(oauth.encodeSignInState(REQUEST_URL_STRING_BUFFER.toString(), session, "content"))
-                .thenReturn(STATE);
+    void doSignInTestToEnsureThatAUserIsSentToTheAuthorisePage() throws IOException {
+        when(oauth2.prepareState(request)).thenReturn(STATE);
         when(identityProvider.getAuthorisationUrl(STATE)).thenReturn(AUTHORISE_URI);
-
-        signInController.redirectForAuth(session, request, response);
-
+        signInController.doSignIn(request, response);
         verify(response).sendRedirect(AUTHORISE_URI);
     }
 

--- a/src/test/java/uk/gov/ch/developer/docs/controller/developer/SignInControllerTest.java
+++ b/src/test/java/uk/gov/ch/developer/docs/controller/developer/SignInControllerTest.java
@@ -34,7 +34,7 @@ public class SignInControllerTest {
     @Mock
     HttpServletResponse response;
     @Mock
-    IOauth oauth2;
+    IOauth oauth;
     @Mock
     IIdentityProvider identityProvider;
     @Mock
@@ -45,7 +45,7 @@ public class SignInControllerTest {
 
     @Test
     void doSignInTestToEnsureThatAUserIsSentToTheAuthorisePage() throws IOException {
-        when(oauth2.prepareState(request)).thenReturn(STATE);
+        when(oauth.prepareState(request)).thenReturn(STATE);
         when(identityProvider.getAuthorisationUrl(STATE)).thenReturn(AUTHORISE_URI);
         signInController.doSignIn(request, response);
         verify(response).sendRedirect(AUTHORISE_URI);

--- a/src/test/java/uk/gov/ch/developer/docs/controller/developer/SignInControllerTest.java
+++ b/src/test/java/uk/gov/ch/developer/docs/controller/developer/SignInControllerTest.java
@@ -1,5 +1,11 @@
 package uk.gov.ch.developer.docs.controller.developer;
 
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -9,13 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.ch.oauth.IOauth;
 import uk.gov.ch.oauth.identity.IIdentityProvider;
 import uk.gov.companieshouse.session.Session;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import uk.gov.companieshouse.session.handler.SessionHandler;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -46,7 +46,8 @@ public class SignInControllerTest {
 
     @Test
     void doSignInTestToEnsureThatAUserIsSentToTheAuthorisePage() throws IOException {
-        when(oauth2.prepareState(request)).thenReturn(STATE);
+        when(request.getAttribute(SessionHandler.CHS_SESSION_REQUEST_ATT_KEY)).thenReturn(session);
+        when(oauth2.prepareState(request, session)).thenReturn(STATE);
         when(identityProvider.getAuthorisationUrl(STATE)).thenReturn(AUTHORISE_URI);
         signInController.doSignIn(request, response);
         verify(response).sendRedirect(AUTHORISE_URI);

--- a/src/test/java/uk/gov/ch/oauth/Oauth2Test.java
+++ b/src/test/java/uk/gov/ch/oauth/Oauth2Test.java
@@ -31,7 +31,6 @@ import java.util.Map;
 
 import static org.junit.Assert.*;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -185,9 +184,9 @@ public class Oauth2Test {
     @Test
     @DisplayName("Test that prepareState returns a valid State String")
     public void testPrepareState() {
-        doReturn(STATE).when(oauth2).encodeSignInState(anyString(), any(Session.class), anyString());
+        doReturn(STATE).when(oauth2).encodeSignInState(ORIGINAL_REQUEST_URL, session, "content");
         when(request.getAttribute(SessionHandler.CHS_SESSION_REQUEST_ATT_KEY)).thenReturn(session);
-        when(request.getRequestURL()).thenReturn(REQUEST_URL_STRING_BUFFER);
+        doReturn(ORIGINAL_REQUEST_URL).when(oauth2).getOriginalRequestURL(request);
         String state = oauth2.prepareState(request);
         assertEquals(STATE, state);
     }

--- a/src/test/java/uk/gov/ch/oauth/Oauth2Test.java
+++ b/src/test/java/uk/gov/ch/oauth/Oauth2Test.java
@@ -39,6 +39,7 @@ import uk.gov.ch.oauth.tokens.OAuthToken;
 import uk.gov.ch.oauth.tokens.UserProfileResponse;
 import uk.gov.companieshouse.session.Session;
 import uk.gov.companieshouse.session.SessionKeys;
+import uk.gov.companieshouse.session.handler.SessionHandler;
 import uk.gov.companieshouse.session.model.SignInInfo;
 import uk.gov.companieshouse.session.store.Store;
 
@@ -184,9 +185,10 @@ public class Oauth2Test {
     @DisplayName("Test that prepareState returns a valid State String")
     public void testPrepareState() {
         doReturn(STATE).when(oauth2).encodeSignInState(ORIGINAL_REQUEST_URL, session, "content");
+        when(request.getAttribute(SessionHandler.CHS_SESSION_REQUEST_ATT_KEY)).thenReturn(session);
         when(request.getRequestURL()).thenReturn(REQUEST_URL_STRING_BUFFER);
         when(request.getQueryString()).thenReturn("original");
-        String state = oauth2.prepareState(request, session);
+        String state = oauth2.prepareState(request);
         assertEquals(STATE, state);
     }
 

--- a/src/test/java/uk/gov/ch/oauth/Oauth2Test.java
+++ b/src/test/java/uk/gov/ch/oauth/Oauth2Test.java
@@ -14,9 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.web.reactive.function.client.ClientResponse;
 import uk.gov.ch.oauth.identity.IIdentityProvider;
-import uk.gov.ch.oauth.nonce.NonceGenerator;
 import uk.gov.ch.oauth.session.SessionFactory;
 import uk.gov.ch.oauth.tokens.OAuthToken;
 import uk.gov.ch.oauth.tokens.UserProfileResponse;
@@ -27,7 +25,6 @@ import uk.gov.companieshouse.session.model.SignInInfo;
 import uk.gov.companieshouse.session.store.Store;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -51,14 +48,6 @@ public class Oauth2Test {
 
     @Mock
     public IIdentityProvider identityProvider;
-    @Mock
-    private OAuth2StateHandler oAuth2StateHandler;
-    @Mock
-    private NonceGenerator nonceGenerator;
-    @Mock
-    public HttpServletResponse httpServletResponse;
-    @Mock
-    public ClientResponse response;
     @Mock
     private Store store;
     @Mock

--- a/src/test/java/uk/gov/ch/oauth/Oauth2Test.java
+++ b/src/test/java/uk/gov/ch/oauth/Oauth2Test.java
@@ -1,11 +1,30 @@
 package uk.gov.ch.oauth;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
 import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -20,18 +39,8 @@ import uk.gov.ch.oauth.tokens.OAuthToken;
 import uk.gov.ch.oauth.tokens.UserProfileResponse;
 import uk.gov.companieshouse.session.Session;
 import uk.gov.companieshouse.session.SessionKeys;
-import uk.gov.companieshouse.session.handler.SessionHandler;
 import uk.gov.companieshouse.session.model.SignInInfo;
 import uk.gov.companieshouse.session.store.Store;
-
-import javax.servlet.http.HttpServletRequest;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.junit.Assert.*;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class Oauth2Test {
@@ -175,10 +184,9 @@ public class Oauth2Test {
     @DisplayName("Test that prepareState returns a valid State String")
     public void testPrepareState() {
         doReturn(STATE).when(oauth2).encodeSignInState(ORIGINAL_REQUEST_URL, session, "content");
-        when(request.getAttribute(SessionHandler.CHS_SESSION_REQUEST_ATT_KEY)).thenReturn(session);
         when(request.getRequestURL()).thenReturn(REQUEST_URL_STRING_BUFFER);
         when(request.getQueryString()).thenReturn("original");
-        String state = oauth2.prepareState(request);
+        String state = oauth2.prepareState(request, session);
         assertEquals(STATE, state);
     }
 

--- a/src/test/java/uk/gov/ch/oauth/Oauth2Test.java
+++ b/src/test/java/uk/gov/ch/oauth/Oauth2Test.java
@@ -39,7 +39,6 @@ import uk.gov.ch.oauth.tokens.OAuthToken;
 import uk.gov.ch.oauth.tokens.UserProfileResponse;
 import uk.gov.companieshouse.session.Session;
 import uk.gov.companieshouse.session.SessionKeys;
-import uk.gov.companieshouse.session.handler.SessionHandler;
 import uk.gov.companieshouse.session.model.SignInInfo;
 import uk.gov.companieshouse.session.store.Store;
 
@@ -185,7 +184,7 @@ public class Oauth2Test {
     @DisplayName("Test that prepareState returns a valid State String")
     public void testPrepareState() {
         doReturn(STATE).when(oauth2).encodeSignInState(ORIGINAL_REQUEST_URL, session, "content");
-        when(request.getAttribute(SessionHandler.CHS_SESSION_REQUEST_ATT_KEY)).thenReturn(session);
+        when(sessionFactory.getSessionFromContext()).thenReturn(session);
         when(request.getRequestURL()).thenReturn(REQUEST_URL_STRING_BUFFER);
         when(request.getQueryString()).thenReturn("original");
         String state = oauth2.prepareState(request);

--- a/src/test/java/uk/gov/ch/oauth/Oauth2Test.java
+++ b/src/test/java/uk/gov/ch/oauth/Oauth2Test.java
@@ -172,21 +172,12 @@ public class Oauth2Test {
     }
 
     @Test
-    @DisplayName("Test that getOriginalURL takes the request and returns the original request URL ")
-    public void testGetOriginalRequestURLReturnsTheCorrectURLAsAString() {
-        when(request.getRequestURL()).thenReturn(REQUEST_URL_STRING_BUFFER);
-        when(request.getQueryString()).thenReturn("original");
-        String actualUrl = oauth2.getOriginalRequestURL(request);
-        assertEquals(ORIGINAL_REQUEST_URL, actualUrl);
-
-    }
-
-    @Test
     @DisplayName("Test that prepareState returns a valid State String")
     public void testPrepareState() {
         doReturn(STATE).when(oauth2).encodeSignInState(ORIGINAL_REQUEST_URL, session, "content");
         when(request.getAttribute(SessionHandler.CHS_SESSION_REQUEST_ATT_KEY)).thenReturn(session);
-        doReturn(ORIGINAL_REQUEST_URL).when(oauth2).getOriginalRequestURL(request);
+        when(request.getRequestURL()).thenReturn(REQUEST_URL_STRING_BUFFER);
+        when(request.getQueryString()).thenReturn("original");
         String state = oauth2.prepareState(request);
         assertEquals(STATE, state);
     }

--- a/src/test/java/uk/gov/ch/oauth/Oauth2Test.java
+++ b/src/test/java/uk/gov/ch/oauth/Oauth2Test.java
@@ -50,7 +50,7 @@ public class Oauth2Test {
     private final SignInInfo signInInfo = new SignInInfo();
     static final String ORIGINAL_REQUEST_URL = "https://www.example.com?original";
     static final StringBuffer REQUEST_URL_STRING_BUFFER = new StringBuffer(
-            "https://www.example.com");
+            "https://www.example.com"); //TODO decide if we should be expecting StringBuffer here or not
     public static final String AUTHORISE_URI = "https://example.com/authorise";
     static final String STATE = "state";
 


### PR DESCRIPTION

__Short description outlining key changes/additions__

Refactored SignInController moving the logic to Oauth2, including getting the original request Url and preparing the state. Altered tests to match accordingly for both SignInControllerTest and Oauth2Test.

__JIRA Ticket Number__

FA-738

### Type of change

* [ ] Bug fix
* [ ] New feature
* [X] Breaking change

### Pull request checklist

* [X] I have added unit tests for new code that I have added
* [X] I have added/updated functional tests where appropriate
* [X] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__