### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <mockito-junit-jupiter.version>3.1.0</mockito-junit-jupiter.version>
-    <oauth-signin-java.version>0.2.2</oauth-signin-java.version>
+    <oauth-signin-java.version>0.2.5</oauth-signin-java.version>
     <spring-boot-dependencies.version>2.2.0.RELEASE</spring-boot-dependencies.version>
     <!--Spring -->
     <spring-boot-maven-plugin.version>2.2.0.RELEASE</spring-boot-maven-plugin.version>
@@ -41,7 +41,7 @@
     <!--Maven -->
     <thymeleaf-extras-java8time.version>3.0.1.RELEASE</thymeleaf-extras-java8time.version>
     <thymeleaf-layout-dialect.version>2.3.0</thymeleaf-layout-dialect.version>
-    <web-security-java.version>1.3.8</web-security-java.version>
+    <web-security-java.version>1.3.10</web-security-java.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
These versions remove the `USE_FINE_GRAIN_SCOPES_MODEL` feature flag

FA-1072