### PR TITLE
Add jib to pom, update README with docker instructions, add Tiltfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ Or start developer-hub by using:
 
 Service can be accessed using the following link: http://dev.chs-dev.internal:4904
 
+## Docker
+To build a Docker image run the following command:
+
+```
+mvn compile jib:dockerBuild
+```
+
+This will output a Docker imaged named: `169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/docs.developer.ch.gov.uk`
+
+You can specify a different image name run `mvn compile jib:dockerBuild -Dimage=<YOUR NAME HERE>`
+
 ## Environment Variables
 The following is a list of mandatory environment variables for the service to run:
 

--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -1,0 +1,18 @@
+local_resource(
+  name = 'dev:docs-developer-ch-gov-uk',
+  cmd = 'mvn compile',
+  deps = ['src']
+)
+
+custom_build(
+  ref = '169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/docs.developer.ch.gov.uk',
+  command = 'mvn compile jib:dockerBuild -Dimage=$EXPECTED_REF',
+  live_update = [
+    sync(
+      local_path = './target/classes',
+      remote_path = '/app/classes'
+    ),
+    restart_container()
+  ],
+  deps = ['./target/classes']
+)

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,16 @@
         <groupId>org.jacoco</groupId>
         <version>${jacoco-maven-plugin.version}</version>
       </plugin>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <version>3.1.1</version>
+        <configuration>
+          <to>
+            <image>169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/docs.developer.ch.gov.uk</image>
+          </to>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Add's jib to the pom.xml, a Tiltfile.dev for use in Docker CHS and updates the README.md with instructions on how to build a Docker image using jib.

https://companieshouse.atlassian.net/browse/BI-8389