### PR TITLE
JU-548: Add security-check, fix security vulnerability and trailing slash problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,11 @@ endif
 .PHONY: dist
 dist: clean build package
 
+.PHONY: security-check
+security-check:
+	mvn org.owasp:dependency-check-maven:update-only
+	mvn org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=4 -DassemblyAnalyzerEnabled=false
+
 .PHONY: sonar
 sonar:
 	mvn org.sonarsource.scanner.maven:sonar-maven-plugin:3.11.0.3922:sonar

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <properties>
     <!--Java & Junit-->
-    <common-web-java.version>1.5.0</common-web-java.version>
+    <common-web-java.version>3.0.22</common-web-java.version>
     <home.url></home.url>
     <java-session-handler.version>4.1.0</java-session-handler.version>
     <java.version>21</java.version>

--- a/src/main/java/uk/gov/ch/developer/docs/config/WebConfig.java
+++ b/src/main/java/uk/gov/ch/developer/docs/config/WebConfig.java
@@ -2,6 +2,7 @@ package uk.gov.ch.developer.docs.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -26,4 +27,9 @@ public class WebConfig implements WebMvcConfigurer {
                 );
     }
 
+    @Override
+    @SuppressWarnings("deprecation") // Trailing slash support deprecated in Spring Boot 3.
+    public void configurePathMatch(PathMatchConfigurer configurer) {
+        configurer.setUseTrailingSlashMatch(true);
+    }
 }

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -42,7 +42,7 @@
 <div th:replace="fragments/header :: header"></div>
 <div class="govuk-width-container">
   <div th:replace="fragments/userBar :: userBar"></div>
-  <div th:replace="fragments/backButtonLink :: backButtonLink"></div>
+  <div th:replace="fragments/back-button :: backLink"></div>
   <div th:switch="${isErrorPage}">
     <!-- Non Error pages require Nav bar and do not have main wrapper in fragment -->
     <div th:case="false" th:remove="tag">

--- a/src/test/java/uk/gov/ch/developer/docs/controller/developer/GetStartedControllerTest.java
+++ b/src/test/java/uk/gov/ch/developer/docs/controller/developer/GetStartedControllerTest.java
@@ -48,6 +48,14 @@ class GetStartedControllerTest {
     }
 
     @Test
+    @DisplayName("Get Get Started Page with trailing slash - success path")
+    void Test_GetRequest_ReturnsSuccess_ForPathWithTrailingSlash() throws Exception {
+        this.mockMvc.perform(get(URL + "/"))
+                .andExpect(status().isOk())
+                .andExpect(view().name(VIEW));
+    }
+
+    @Test
     @DisplayName("Get Get Started Page - Failure path")
     void Test_GetRequest_ReturnsError_ForIncorrectPath() throws Exception {
         this.mockMvc.perform(get(ApplicationVariables.BAD_REQUEST_URL))

--- a/suppress.xml
+++ b/suppress.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions>


### PR DESCRIPTION
__Short description outlining key changes/additions__

* Add the `security-check` target  to implement the check for the pipeline `security-check` job.
* Upgrade to latest `common-web-java` to avoid vulnerability [CVE-2021-4236](https://github.com/advisories/GHSA-jpgg-cp2x-qrw3).
* Re-enable support for trailing slashes in request URLs, disabled by default in Spring Boot 3.

__JIRA Ticket Number__

[JU-548](https://companieshouse.atlassian.net/browse/JU-548)

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [X] I have added/updated functional tests where appropriate
* [X] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__

[JU-548]: https://companieshouse.atlassian.net/browse/JU-548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ