### PR TITLE
Set dependency-check up according to current standards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,7 @@ artifact_name       := docs.developer.ch.gov.uk
 version             := "unversioned"
 
 dependency_check_base_suppressions:=common_suppressions_spring_6.xml
-
-# dependency_check_suppressions_repo_branch
-# The branch of the dependency-check-suppressions repository to use
-# as the source of the suppressions file.
-# This should point to "main" branch when being used for release,
-# but can point to a different branch for experimentation/development.
-dependency_check_suppressions_repo_branch:=feature/suppressions-for-company-accounts-api
-
+dependency_check_suppressions_repo_branch:=main
 dependency_check_minimum_cvss := 4
 dependency_check_assembly_analyzer_enabled := false
 dependency_check_suppressions_repo_url:=git@github.com:companieshouse/dependency-check-suppressions.git
@@ -64,10 +57,6 @@ sonar:
 sonar-pr-analysis:
 	mvn sonar:sonar -P sonar-pr-analysis
 
-.PHONY: security-check
-security-check: dependency-check
-
-
 .PHONY: build-image
 build-image:
 	@echo "Running build-image"
@@ -96,7 +85,7 @@ dependency-check:
 			mkdir -p "./target"; \
 			git clone $(dependency_check_suppressions_repo_url) "$${suppressions_home_target_dir}" && \
 				suppressions_home="$${suppressions_home_target_dir}"; \
-			  if [ -d "$${suppressions_home_target_dir}" ] && [ -n "$(dependency_check_suppressions_repo_branch)" ]; then \
+			if [ -d "$${suppressions_home_target_dir}" ] && [ -n "$(dependency_check_suppressions_repo_branch)" ]; then \
 				cd "$${suppressions_home}"; \
 				git checkout $(dependency_check_suppressions_repo_branch); \
 				cd -; \
@@ -106,9 +95,12 @@ dependency-check:
 	suppressions_path="$${suppressions_home}/suppressions/$(dependency_check_base_suppressions)"; \
 	if [  -f "$${suppressions_path}" ]; then \
 		cp -av "$${suppressions_path}" $(suppressions_file); \
-		mvn org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=$(dependency_check_minimum_cvss) -DassemblyAnalyzerEnabled=$(dependency_check_assembly_analyzer_enabled) -DsuppressionFiles=$(suppressions_file); \
+		mvn org.owasp:dependency-check-maven:check -Dformats="json,html" -DprettyPrint -DfailBuildOnCVSS=$(dependency_check_minimum_cvss) -DassemblyAnalyzerEnabled=$(dependency_check_assembly_analyzer_enabled) -DsuppressionFiles=$(suppressions_file); \
 	else \
 		printf -- "\n ERROR Cannot find suppressions file at '%s'\n" "$${suppressions_path}" >&2; \
 		exit 1; \
 	fi
+
+.PHONY: security-check
+security-check: dependency-check
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>companies-house-parent</artifactId>
     <groupId>uk.gov.companieshouse</groupId>
-    <version>2.1.6</version>
+    <version>2.1.11</version>
     <relativePath/>
   </parent>
 

--- a/suppress.xml
+++ b/suppress.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-</suppressions>


### PR DESCRIPTION
Tidy, repoint at dep-check-suppressions/main
The 'dependency-check' target uses a variable dependency_check_suppressions_repo_branch which previously pointed to a different branch: feature/suppressions-for-company-accounts-api ... but that branch has been merged into main and so this variable should now point to main.

Update parent pom to 2.1.11
2.1.11 brings in latest correct dependency-check settings.

Delete outdated suppress.xml
The suppress.xml is now pulled from dependency-check-suppressions repo.

See [CC-1742](https://companieshouse.atlassian.net/browse/CC-1742)

[CC-1742]: https://companieshouse.atlassian.net/browse/CC-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ