### PR TITLE
Updated Makefile for dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,6 @@
 artifact_name       := docs.developer.ch.gov.uk
 version             := "unversioned"
 
-dependency_check_base_suppressions:=common_suppressions_spring_6.xml
-dependency_check_suppressions_repo_branch:=main
-dependency_check_minimum_cvss := 4
-dependency_check_assembly_analyzer_enabled := false
-dependency_check_suppressions_repo_url:=git@github.com:companieshouse/dependency-check-suppressions.git
-suppressions_file := target/suppressions.xml
-
 .PHONY: all
 all: build
 
@@ -70,31 +63,4 @@ all: clean build build-image
 .PHONY: run
 run:
 	docker run -it --rm $(artifact_name)
-
-
-.PHONY: dependency-check
-dependency-check:
-	@ if [ -n "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)" ]; then \
-		if [ -d "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)" ]; then \
-			suppressions_home="$${DEPENDENCY_CHECK_SUPPRESSIONS_HOME}"; \
-		else \
-			printf -- 'DEPENDENCY_CHECK_SUPPRESSIONS_HOME is set, but its value "%s" does not point to a directory\n' "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)"; \
-			exit 1; \
-		fi; \
-	fi; \
-	if [ ! -d "$${suppressions_home}" ]; then \
-		suppressions_home_target_dir="./target/dependency-check-suppressions"; \
-		if [ -d "$${suppressions_home_target_dir}" ]; then \
-			suppressions_home="$${suppressions_home_target_dir}"; \
-		else \
-			mkdir -p "./target"; \
-			git clone git@github.com:companieshouse/dependency-check-suppressions.git "$${suppressions_home_target_dir}" && \
-				suppressions_home="$${suppressions_home_target_dir}"; \
-		fi; \
-	fi; \
-	printf -- 'suppressions_home="%s"\n' "$${suppressions_home}"; \
-	DEPENDENCY_CHECK_SUPPRESSIONS_HOME="$${suppressions_home}" "$${suppressions_home}/scripts/depcheck" --repo-name=TodoMyRepoName
-
-.PHONY: security-check
-security-check: dependency-check
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>companies-house-parent</artifactId>
     <groupId>uk.gov.companieshouse</groupId>
-    <version>2.1.11</version>
+    <version>2.1.12</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
removed the dependency check section from the Makefile as a part of migrating to a centralized vulnerability scanning approach managed via the CI pipeline.
Updated parent pom to 2.1.12, use relativePath 2.1.12 brings in updated dependency-check settings.